### PR TITLE
closes #7

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ const shuffleList = (list) => {
 
 const filterByName = (searchForName, personList) => {
     return personList.filter((person) => {
-        return person.name === searchForName;
+        return person.name.toLowerCase().includes(searchForName.toLowerCase());
     });
 }
 


### PR DESCRIPTION
:goat:
Switched the search functionality to look for names that include a non-case-sensitive version of the search input value instead of searching for EXACTLY what's in the search input.